### PR TITLE
[Demo app] Remove superfluous `url` prop on `PdfHighlighter`

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -141,7 +141,6 @@ class App extends Component<Props, State> {
 
                   this.scrollToHighlightFromHash();
                 }}
-                url={url}
                 onSelectionFinished={(
                   position,
                   content,


### PR DESCRIPTION
`PdfHighlighter` does not accept/use the `url` prop - `PdfLoader` does.