### PR TITLE
Change falsy check for `scaled.x1` coord

### DIFF
--- a/src/lib/coordinates.js
+++ b/src/lib/coordinates.js
@@ -54,7 +54,7 @@ export const scaledToViewport = (
     return pdfToViewport(scaled, viewport);
   }
 
-  if (!scaled.x1) {
+  if (scaled.x1 === null || scaled.x1 === undefined) {
     throw new Error("You are using old position format, please update");
   }
 


### PR DESCRIPTION
Right now, this check throws an error when `scaled.x1` is set to `0`. Making the check more explicit for `null` and `undefined`.

Thanks~