### PR TITLE
set the viewer for the link service

### DIFF
--- a/src/components/PdfHighlighter.js
+++ b/src/components/PdfHighlighter.js
@@ -135,6 +135,7 @@ class PdfHighlighter<T_HT: T_Highlight> extends Component<
 
     this.viewer.setDocument(pdfDocument);
     this.linkService.setDocument(pdfDocument);
+    this.linkService.setViewer(this.viewer);
 
     // debug
     window.PdfViewer = this;


### PR DESCRIPTION
Setting the viewer for the link service allows one to follow links to other sections within the pdf being viewed.