### PR TITLE
Update to pass the right props

### DIFF
--- a/packages/react-pdf-highlighter/src/components/Tip.js
+++ b/packages/react-pdf-highlighter/src/components/Tip.js
@@ -34,8 +34,13 @@ class Tip extends Component<Props, State> {
 
   render() {
     const { onConfirm, onOpen } = this.props;
+    let { emojiOptions, popupPlaceholder, buttonName } = this.props;
     const { compact, text, emoji } = this.state;
-
+    emojiOptions = emojiOptions
+      ? emojiOptions
+      : ["💩", "😱", "😍", "🔥", "😳", "⚠️"];
+    popupPlaceholder = popupPlaceholder ? popupPlaceholder : "Your comment";
+    buttonName = buttonName ? buttonName : "Save";
     return (
       <div className="Tip">
         {compact ? (
@@ -59,7 +64,7 @@ class Tip extends Component<Props, State> {
             <div>
               <textarea
                 width="100%"
-                placeholder="Your comment"
+                placeholder={popupPlaceholder}
                 autoFocus
                 value={text}
                 onChange={event => this.setState({ text: event.target.value })}
@@ -70,7 +75,7 @@ class Tip extends Component<Props, State> {
                 }}
               />
               <div>
-                {["💩", "😱", "😍", "🔥", "😳", "⚠️"].map(_emoji => (
+                {emojiOptions.map(_emoji => (
                   <label key={_emoji}>
                     <input
                       checked={emoji === _emoji}
@@ -87,7 +92,7 @@ class Tip extends Component<Props, State> {
               </div>
             </div>
             <div>
-              <input type="submit" value="Save" />
+              <input type="submit" value={buttonName} />
             </div>
           </form>
         )}


### PR DESCRIPTION
Several developers would like to customize the props of the Tip Component so they can use their own text instead of emojis.

Now with this small fix, we can pass the props like this

emojiOptions = {['Section','Text','Diagram','Heading','Table']} //instead of poop emojis
popupPlaceholder = "Enter Highlight ID" //more text 
buttonName = "Select" //instead of Save

