### PR TITLE
Implement onChangeStart callback to AreaHighlight

### DIFF
--- a/packages/react-pdf-highlighter/src/components/AreaHighlight.js
+++ b/packages/react-pdf-highlighter/src/components/AreaHighlight.js
@@ -10,12 +10,13 @@ import type { T_ViewportHighlight, T_LTWH } from "../types";
 
 type Props = {|
   highlight: T_ViewportHighlight,
-  onChange: (rect: T_LTWH) => void
+  onChange: (rect: T_LTWH) => void,
+  onChangeStart?: () => void
 |};
 
 class AreaHighlight extends Component<Props> {
   render() {
-    const { highlight, onChange, ...otherProps } = this.props;
+    const { highlight, onChange, onChangeStart, ...otherProps } = this.props;
 
     return (
       <Rnd
@@ -51,6 +52,8 @@ class AreaHighlight extends Component<Props> {
           event.stopPropagation();
           event.preventDefault();
         }}
+        onResizeStart={onChangeStart ? () => onChangeStart() : undefined}
+        onDragStart={onChangeStart ? () => onChangeStart() : undefined}
         {...otherProps}
       />
     );

--- a/packages/react-pdf-highlighter/src/components/MouseSelection.js
+++ b/packages/react-pdf-highlighter/src/components/MouseSelection.js
@@ -15,7 +15,8 @@ type Coords = {
 type State = {
   locked: boolean,
   start: ?Coords,
-  end: ?Coords
+  end: ?Coords,
+  startTarget: HTMLElement | null
 };
 
 type Props = {
@@ -57,7 +58,7 @@ class MouseSelection extends Component<Props, State> {
     };
   }
 
-  getContainer = () => asElement(this.root.parentElement);
+  getContainer = () => (this.root ? asElement(this.root.parentElement) : null);
 
   getContainerCoords = (
     pageX: number,
@@ -65,6 +66,7 @@ class MouseSelection extends Component<Props, State> {
     container?: HTMLElement
   ) => {
     const containerElem = container || this.getContainer();
+    if (!containerElem) throw new Error("Container not found");
     let containerBoundingRect = null;
 
     if (!containerBoundingRect) {
@@ -102,6 +104,7 @@ class MouseSelection extends Component<Props, State> {
     }
 
     const container = this.getContainer();
+    if (!container) throw new Error("Container not found");
     const end = this.getContainerCoords(event.pageX, event.pageY, container);
 
     const boundingRect = this.getBoundingRect(start, end);
@@ -127,7 +130,7 @@ class MouseSelection extends Component<Props, State> {
           return;
         }
 
-        if (isHTMLElement(event.target)) {
+        if (isHTMLElement(event.target) && this.state.startTarget) {
           onSelection(this.state.startTarget, boundingRect, this.reset);
 
           onDragEnd();
@@ -152,6 +155,7 @@ class MouseSelection extends Component<Props, State> {
     }
 
     const container = this.getContainer();
+    if (!container) throw new Error("Container not found");
 
     onDragStart();
 
@@ -195,8 +199,7 @@ class MouseSelection extends Component<Props, State> {
   }
 
   componentWillUnmount() {
-    console.log("Mouse selection will unmount, remove event listeners");
-    const container = asElement(this.root.parentElement);
+    const container = this.root ? asElement(this.root.parentElement) : null;
     if (!container) return;
 
     container.removeEventListener("mousemove", this.onMouseMove);

--- a/packages/react-pdf-highlighter/src/components/MouseSelection.js
+++ b/packages/react-pdf-highlighter/src/components/MouseSelection.js
@@ -34,7 +34,8 @@ class MouseSelection extends Component<Props, State> {
   state: State = {
     locked: false,
     start: null,
-    end: null
+    end: null,
+    startTarget: null
   };
 
   root: ?HTMLElement;
@@ -56,6 +57,117 @@ class MouseSelection extends Component<Props, State> {
     };
   }
 
+  getContainer = () => asElement(this.root.parentElement);
+
+  getContainerCoords = (
+    pageX: number,
+    pageY: number,
+    container?: HTMLElement
+  ) => {
+    const containerElem = container || this.getContainer();
+    let containerBoundingRect = null;
+
+    if (!containerBoundingRect) {
+      containerBoundingRect = containerElem.getBoundingClientRect();
+    }
+
+    return {
+      x: pageX - containerBoundingRect.left + containerElem.scrollLeft,
+      y: pageY - containerBoundingRect.top + containerElem.scrollTop
+    };
+  };
+
+  onMouseMove = (event: MouseEvent) => {
+    const { start, locked } = this.state;
+
+    if (!start || locked) {
+      return;
+    }
+
+    this.setState({
+      ...this.state,
+      end: this.getContainerCoords(event.pageX, event.pageY)
+    });
+  };
+
+  onMouseUp = (event: MouseEvent) => {
+    const { onSelection, onDragEnd } = this.props;
+    // emulate listen once
+    event.currentTarget.removeEventListener("mouseup", this.onMouseUp);
+
+    const { start } = this.state;
+
+    if (!start) {
+      return;
+    }
+
+    const container = this.getContainer();
+    const end = this.getContainerCoords(event.pageX, event.pageY, container);
+
+    const boundingRect = this.getBoundingRect(start, end);
+
+    if (
+      !isHTMLElement(event.target) ||
+      !container.contains(asElement(event.target)) ||
+      !this.shouldRender(boundingRect)
+    ) {
+      this.reset();
+      return;
+    }
+
+    this.setState(
+      {
+        end,
+        locked: true
+      },
+      () => {
+        const { start, end } = this.state;
+
+        if (!start || !end) {
+          return;
+        }
+
+        if (isHTMLElement(event.target)) {
+          onSelection(this.state.startTarget, boundingRect, this.reset);
+
+          onDragEnd();
+          this.setState({
+            startTarget: null
+          });
+        }
+      }
+    );
+  };
+
+  onMouseDown = (event: MouseEvent) => {
+    const { onDragStart, shouldStart } = this.props;
+    if (!shouldStart(event)) {
+      this.reset();
+      return;
+    }
+
+    const startTarget = asElement(event.target);
+    if (!isHTMLElement(startTarget)) {
+      return;
+    }
+
+    const container = this.getContainer();
+
+    onDragStart();
+
+    this.setState({
+      start: this.getContainerCoords(event.pageX, event.pageY, container),
+      end: null,
+      locked: false,
+      startTarget
+    });
+
+    const { ownerDocument: doc } = container;
+    if (doc.body) {
+      doc.body.addEventListener("mouseup", this.onMouseUp);
+    }
+  };
+
   componentDidUpdate() {
     const { onChange } = this.props;
     const { start, end } = this.state;
@@ -72,108 +184,29 @@ class MouseSelection extends Component<Props, State> {
 
     const that = this;
 
-    const { onSelection, onDragStart, onDragEnd, shouldStart } = this.props;
-
     const container = asElement(this.root.parentElement);
 
     if (!isHTMLElement(container)) {
       return;
     }
 
-    let containerBoundingRect = null;
+    container.addEventListener("mousemove", this.onMouseMove);
+    container.addEventListener("mousedown", this.onMouseDown);
+  }
 
-    const containerCoords = (pageX: number, pageY: number) => {
-      if (!containerBoundingRect) {
-        containerBoundingRect = container.getBoundingClientRect();
-      }
+  componentWillUnmount() {
+    console.log("Mouse selection will unmount, remove event listeners");
+    const container = asElement(this.root.parentElement);
+    if (!container) return;
 
-      return {
-        x: pageX - containerBoundingRect.left + container.scrollLeft,
-        y: pageY - containerBoundingRect.top + container.scrollTop
-      };
-    };
+    container.removeEventListener("mousemove", this.onMouseMove);
+    container.removeEventListener("mousedown", this.onMouseDown);
 
-    container.addEventListener("mousemove", (event: MouseEvent) => {
-      const { start, locked } = this.state;
-
-      if (!start || locked) {
-        return;
-      }
-
-      that.setState({
-        ...this.state,
-        end: containerCoords(event.pageX, event.pageY)
-      });
-    });
-
-    container.addEventListener("mousedown", (event: MouseEvent) => {
-      if (!shouldStart(event)) {
-        this.reset();
-        return;
-      }
-
-      const startTarget = asElement(event.target);
-      if (!isHTMLElement(startTarget)) {
-        return;
-      }
-
-      onDragStart();
-
-      this.setState({
-        start: containerCoords(event.pageX, event.pageY),
-        end: null,
-        locked: false
-      });
-
-      const onMouseUp = (event: MouseEvent): void => {
-        // emulate listen once
-        event.currentTarget.removeEventListener("mouseup", onMouseUp);
-
-        const { start } = this.state;
-
-        if (!start) {
-          return;
-        }
-
-        const end = containerCoords(event.pageX, event.pageY);
-
-        const boundingRect = that.getBoundingRect(start, end);
-
-        if (
-          !isHTMLElement(event.target) ||
-          !container.contains(asElement(event.target)) ||
-          !that.shouldRender(boundingRect)
-        ) {
-          that.reset();
-          return;
-        }
-
-        that.setState(
-          {
-            end,
-            locked: true
-          },
-          () => {
-            const { start, end } = that.state;
-
-            if (!start || !end) {
-              return;
-            }
-
-            if (isHTMLElement(event.target)) {
-              onSelection(startTarget, boundingRect, that.reset);
-
-              onDragEnd();
-            }
-          }
-        );
-      };
-
-      const { ownerDocument: doc } = container;
-      if (doc.body) {
-        doc.body.addEventListener("mouseup", onMouseUp);
-      }
-    });
+    if (container.ownerDocument.body)
+      container.ownerDocument.body.removeEventListener(
+        "mouseup",
+        this.onMouseUp
+      );
   }
 
   shouldRender(boundingRect: T_LTWH) {


### PR DESCRIPTION
In our project we have the use case, that we toggle between area and text selection with a button instead of pressing the alt key.
This resulted in the behavior that while in area mode, moving or resizing an existing area would result in the start of a new area selection the same time.
![grafik](https://user-images.githubusercontent.com/1684826/103639102-2020dc80-4f4e-11eb-966c-a5c2502640db.png)

To prevent this, I added a callback `onChangeStart` to `AreaHighlight`, so my control is able to remove the `enableAreaSelection` callback as soon as a drag or resizing of an existing area is started.

Since the `shouldStart` check using `enableAreaSelection()` will be triggered before `onChangeStart`, I do not have the information of a started drag already inside of `enableAreaSelection()`, so I have to remove that callback after the `MouseSelection` component is already doing its job.

Since this will result in the unmounting of the `MouseSelection` component, I had to refactor things in this component to properly remove all event listeners in `componentWillUnmount()` to avoid state updates of an unmounted component.

Sample Code:
```jsx
      <AreaHighlight
        highlight={highlight}
        onChangeStart={() => setAreaChanging(true)}
        onChange={(boundingRect) => {
          setAreaChanging(false);
          updateHighlight(
            highlight.id,
            { boundingRect: viewportToScaled(boundingRect) },
            { image: screenshot(boundingRect) },
          );
        }}
      />
```
```jsx
      <PdfHighlighter
        pdfDocument={doc}
        enableAreaSelection={
          mode === 'areaSelection' && !areaChanging ? () => true : null
        }
        …
      </PdfHighlighter>
```
