### PR TITLE
open external links in a new tab

### DIFF
--- a/packages/react-pdf-highlighter/src/components/PdfHighlighter.js
+++ b/packages/react-pdf-highlighter/src/components/PdfHighlighter.js
@@ -110,7 +110,8 @@ class PdfHighlighter<T_HT: T_Highlight> extends PureComponent<
 
   eventBus: T_EventBus = new EventBus();
   linkService: T_PDFJS_LinkService = new PDFLinkService({
-    eventBus: this.eventBus
+    eventBus: this.eventBus,
+    externalLinkTarget: 2
   });
   viewer: T_PDFJS_Viewer;
 


### PR DESCRIPTION
At the moment, external links included in the PDF document won't open in a new tab.
Since the point of this app is to manage and make annotations, navigating away in the same tab when clicking a link could result in data loss or other inconveniences. I don't see any use case to make this configurable, so I think it's fine to just change that behavior globally.

This PR sets the attribute `externalLinkTarget` of the already used `PDFLinkService`, like it is described [here](https://github.com/mozilla/pdf.js/issues/7779#issuecomment-393695189). 