### PR TITLE
Pass PdfLoader options to getDocument

### DIFF
--- a/packages/react-pdf-highlighter/src/components/PdfLoader.js
+++ b/packages/react-pdf-highlighter/src/components/PdfLoader.js
@@ -84,7 +84,7 @@ class PdfLoader extends Component<Props, State> {
       .then(
         () =>
           url &&
-          getDocument({ url, ownerDocument }).promise.then(pdfDocument => {
+          getDocument({ ...this.props, ownerDocument }).promise.then(pdfDocument => {
             this.setState({ pdfDocument });
           })
       )


### PR DESCRIPTION
This change will make it possible to pass additional options like withCredentials and password to underlying pdf.js

[pdfjsLib doc](https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib.html)