### PR TITLE
Add cMap options to PdfLoader

### DIFF
--- a/packages/react-pdf-highlighter/src/components/PdfLoader.js
+++ b/packages/react-pdf-highlighter/src/components/PdfLoader.js
@@ -30,7 +30,9 @@ type Props = {
   beforeLoad: React$Element<*>,
   errorMessage?: React$Element<*>,
   children: (pdfDocument: T_PDFJS_Document) => React$Element<*>,
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void,
+  cMapUrl?: string,
+  cMapPacked?: boolean
 };
 
 type State = {
@@ -75,7 +77,7 @@ class PdfLoader extends Component<Props, State> {
 
   load() {
     const { ownerDocument = document } = this.documentRef.current || {};
-    const { url } = this.props;
+    const { url, cMapUrl, cMapPacked } = this.props;
     const { pdfDocument: discardedDocument } = this.state;
     this.setState({ pdfDocument: null, error: null });
 
@@ -84,9 +86,11 @@ class PdfLoader extends Component<Props, State> {
       .then(
         () =>
           url &&
-          getDocument({ url, ownerDocument }).promise.then(pdfDocument => {
-            this.setState({ pdfDocument });
-          })
+          getDocument({ url, ownerDocument, cMapUrl, cMapPacked }).promise.then(
+            pdfDocument => {
+              this.setState({ pdfDocument });
+            }
+          )
       )
       .catch(e => this.componentDidCatch(e));
   }


### PR DESCRIPTION
Hi! Thank you very much for your excellent work. It is such a useful library.

## WHAT

I added options about cMap to props of PdfLoader to inject the options from other component.

https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib.html

## WHY

The options are important for some PDFs that contain special characters to render the PDF correctly.

## Testing

I confirmed that it is working properly in example package.

### Without cMap

<img width="1680" alt="スクリーンショット 2021-02-07 10 59 04" src="https://user-images.githubusercontent.com/78351950/107134256-b2444800-6933-11eb-8096-209ece1fc023.png">

### With cMap



<img width="1680" alt="スクリーンショット 2021-02-07 10 58 34" src="https://user-images.githubusercontent.com/78351950/107134259-ba03ec80-6933-11eb-93be-aa8dbce502af.png">


```diff
--- a/packages/example/src/App.js
+++ b/packages/example/src/App.js
@@ -158,7 +158,7 @@ class App extends Component<Props, State> {
             position: "relative"
           }}
         >
-          <PdfLoader url={url} beforeLoad={<Spinner />}>
+          <PdfLoader url={url} cMapUrl={"https://cdn.jsdelivr.net/npm/pdfjs-dist@2.6.347/cmaps/"} cMapPacked={true} beforeLoad={<Spinner />}>
             {pdfDocument => (
               <PdfHighlighter
                 pdfDocument={pdfDocument}
```


