### PR TITLE
add: isScrolledTo prop to AreaHighlight component

### DIFF
--- a/packages/example/src/App.js
+++ b/packages/example/src/App.js
@@ -206,6 +206,7 @@ class App extends Component<Props, State> {
                     />
                   ) : (
                     <AreaHighlight
+                      isScrolledTo={isScrolledTo}
                       highlight={highlight}
                       onChange={boundingRect => {
                         this.updateHighlight(

--- a/packages/react-pdf-highlighter/src/components/AreaHighlight.js
+++ b/packages/react-pdf-highlighter/src/components/AreaHighlight.js
@@ -6,53 +6,60 @@ import { Rnd } from "react-rnd";
 
 import "../style/AreaHighlight.css";
 
-import type { T_ViewportHighlight, T_LTWH } from "../types";
+import type { T_LTWH, T_ViewportHighlight } from "../types";
 
 type Props = {|
   highlight: T_ViewportHighlight,
-  onChange: (rect: T_LTWH) => void
+  onChange: (rect: T_LTWH) => void,
+  isScrolledTo: boolean
 |};
 
 class AreaHighlight extends Component<Props> {
   render() {
-    const { highlight, onChange, ...otherProps } = this.props;
+    const { highlight, onChange, isScrolledTo, ...otherProps } = this.props;
 
     return (
-      <Rnd
-        className="AreaHighlight"
-        onDragStop={(_, data) => {
-          const boundingRect = {
-            ...highlight.position.boundingRect,
-            top: data.y,
-            left: data.x
-          };
+      <div
+        className={`AreaHighlight ${
+          isScrolledTo ? "AreaHighlight--scrolledTo" : ""
+        }`}
+      >
+        <Rnd
+          className="AreaHighlight__part"
+          onDragStop={(_, data) => {
+            const boundingRect = {
+              ...highlight.position.boundingRect,
+              top: data.y,
+              left: data.x
+            };
 
-          onChange(boundingRect);
-        }}
-        onResizeStop={(_, direction, ref, delta, position) => {
-          const boundingRect = {
-            top: position.y,
-            left: position.x,
-            width: ref.offsetWidth,
-            height: ref.offsetHeight
-          };
+            onChange(boundingRect);
+          }}
+          onResizeStop={(_, direction, ref, delta, position) => {
+            const boundingRect = {
+              top: position.y,
+              left: position.x,
+              width: ref.offsetWidth,
+              height: ref.offsetHeight
+            };
 
-          onChange(boundingRect);
-        }}
-        position={{
-          x: highlight.position.boundingRect.left,
-          y: highlight.position.boundingRect.top
-        }}
-        size={{
-          width: highlight.position.boundingRect.width,
-          height: highlight.position.boundingRect.height
-        }}
-        onClick={event => {
-          event.stopPropagation();
-          event.preventDefault();
-        }}
-        {...otherProps}
-      />
+            onChange(boundingRect);
+          }}
+          position={{
+            x: highlight.position.boundingRect.left,
+            y: highlight.position.boundingRect.top
+          }}
+          size={{
+            width: highlight.position.boundingRect.width,
+            height: highlight.position.boundingRect.height
+          }}
+          onClick={event => {
+            event.stopPropagation();
+            event.preventDefault();
+          }}
+          {...otherProps}
+        />
+      </div>
     );
   }
 }

--- a/packages/react-pdf-highlighter/src/style/AreaHighlight.css
+++ b/packages/react-pdf-highlighter/src/style/AreaHighlight.css
@@ -4,3 +4,14 @@
   opacity: 1;
   mix-blend-mode: multiply;
 }
+
+.AreaHighlight__part {
+  cursor: pointer;
+  position: absolute;
+  background: rgba(255, 226, 143, 1);
+  transition: background 0.3s;
+}
+
+.AreaHighlight--scrolledTo .AreaHighlight__part {
+  background: #ff4141;
+}


### PR DESCRIPTION
Similarly to what we have for a `Highlight` component, we now pass a boolean (`isScrolledTo`) to the `AreaHighlight` to enable conditional styling.

We now have a red coloring of an `AreaHighlight` upon selection.

I added styling for `AreaHighlight.css` similar to the one in `Highlight.css` to have a consistent color transition experience on both `Highlight` and `AreaHighlight`

Relates to issue https://github.com/agentcooper/react-pdf-highlighter/issues/127

Result on the example project:
![2021-04-19 13 54 53](https://user-images.githubusercontent.com/29223998/115232317-dc29a000-a116-11eb-88ff-180bc5464584.gif)
