### PR TITLE
Pass PdfLoader props to getDocument

### DIFF
--- a/packages/react-pdf-highlighter/src/components/PdfLoader.js
+++ b/packages/react-pdf-highlighter/src/components/PdfLoader.js
@@ -86,11 +86,14 @@ class PdfLoader extends Component<Props, State> {
       .then(
         () =>
           url &&
-          getDocument({ url, ownerDocument, cMapUrl, cMapPacked }).promise.then(
-            pdfDocument => {
-              this.setState({ pdfDocument });
-            }
-          )
+          getDocument({
+            ...this.props,
+            ownerDocument,
+            cMapUrl,
+            cMapPacked
+          }).promise.then(pdfDocument => {
+            this.setState({ pdfDocument });
+          })
       )
       .catch(e => this.componentDidCatch(e));
   }


### PR DESCRIPTION
This is a duplicate of https://github.com/agentcooper/react-pdf-highlighter/pull/110 but with the Prettier issue fixed. It would be great to have the option to provide `DocumentInitParameters` to `<PdfLoader />`.

Thanks.