### PR TITLE
FIX - Infinite loop caused by selection content in more than 2 pages.

### DIFF
--- a/src/lib/pdfjs-dom.ts
+++ b/src/lib/pdfjs-dom.ts
@@ -62,6 +62,7 @@ export const getPagesFromRange = (range: Range): Page[] => {
     if (currentPage) {
       pages.push(currentPage);
     }
+    currentPageNumber++;
   }
 
   return pages as Page[];


### PR DESCRIPTION
An Infinite loop happens when selecting content in more than 2 pages. 

This PR fixes [that](https://github.com/agentcooper/react-pdf-highlighter/issues/172)