### PR TITLE
FIX - include rectangles not visible in the viewport

### DIFF
--- a/src/lib/get-client-rects.ts
+++ b/src/lib/get-client-rects.ts
@@ -34,8 +34,6 @@ const getClientRects = (
 
       if (
         isClientRectInsidePageRect(clientRect, pageRect) &&
-        clientRect.top >= 0 &&
-        clientRect.bottom >= 0 &&
         clientRect.width > 0 &&
         clientRect.height > 0 &&
         clientRect.width < pageRect.width &&


### PR DESCRIPTION
This fixes the issue of not including highlight rectangles which are not visibile in the viewport.

The issue was happening because the `top` and `bottom` attributes from `clientRect` are negative when the highlight rectangle is not visible in the viewport.