### PR TITLE
chore: bump pdf.js version and fix typing compatiblity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@types/lodash.debounce": "^4.0.6",
-        "@types/pdfjs-dist": "^2.7.4",
         "@types/react": "^16.4.0",
         "@types/react-dom": "^16.4.0",
         "lodash.debounce": "^4.0.8",
-        "pdfjs-dist": "2.11.338",
+        "pdfjs-dist": "2.16.105",
         "react-rnd": "^10.1.10"
       },
       "devDependencies": {
@@ -1405,11 +1404,6 @@
       "integrity": "sha512-25QXpDsTiDnl2rZGUenagVMwO46way8dOUdvoC3R3p+6TrbpxeJBo/v87BEG1IHI31Jhaa8lPeSHcqwxsVBeYQ==",
       "devOptional": true
     },
-    "node_modules/@types/pdfjs-dist": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@types/pdfjs-dist/-/pdfjs-dist-2.7.4.tgz",
-      "integrity": "sha512-X4CpJgsDr44/xq/SK8NukTV2uyRAMz9dXAVHMUtJrBPtpf4CYnbQevmD95G9fbNwsjJNItOlgsS+yECrBJLUHw=="
-    },
     "node_modules/@types/prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
@@ -2505,6 +2499,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dommatrix": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dommatrix/-/dommatrix-1.0.3.tgz",
+      "integrity": "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.3.822",
@@ -6427,9 +6426,13 @@
       "dev": true
     },
     "node_modules/pdfjs-dist": {
-      "version": "2.11.338",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.11.338.tgz",
-      "integrity": "sha512-Ti5VTB0VvSdtTtc7TG71ghMx0SEuNcEs4ghVuZxW0p6OqLjMc0xekZV1B+MmlxEG2Du2e5jgazucWIG/SXTcdA==",
+      "version": "2.16.105",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz",
+      "integrity": "sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==",
+      "dependencies": {
+        "dommatrix": "^1.0.3",
+        "web-streams-polyfill": "^3.2.1"
+      },
       "peerDependencies": {
         "worker-loader": "^3.0.8"
       },
@@ -7659,6 +7662,14 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -9042,11 +9053,6 @@
       "integrity": "sha512-25QXpDsTiDnl2rZGUenagVMwO46way8dOUdvoC3R3p+6TrbpxeJBo/v87BEG1IHI31Jhaa8lPeSHcqwxsVBeYQ==",
       "devOptional": true
     },
-    "@types/pdfjs-dist": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@types/pdfjs-dist/-/pdfjs-dist-2.7.4.tgz",
-      "integrity": "sha512-X4CpJgsDr44/xq/SK8NukTV2uyRAMz9dXAVHMUtJrBPtpf4CYnbQevmD95G9fbNwsjJNItOlgsS+yECrBJLUHw=="
-    },
     "@types/prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
@@ -9944,6 +9950,11 @@
           "dev": true
         }
       }
+    },
+    "dommatrix": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dommatrix/-/dommatrix-1.0.3.tgz",
+      "integrity": "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww=="
     },
     "electron-to-chromium": {
       "version": "1.3.822",
@@ -12790,10 +12801,13 @@
       "dev": true
     },
     "pdfjs-dist": {
-      "version": "2.11.338",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.11.338.tgz",
-      "integrity": "sha512-Ti5VTB0VvSdtTtc7TG71ghMx0SEuNcEs4ghVuZxW0p6OqLjMc0xekZV1B+MmlxEG2Du2e5jgazucWIG/SXTcdA==",
-      "requires": {}
+      "version": "2.16.105",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz",
+      "integrity": "sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==",
+      "requires": {
+        "dommatrix": "^1.0.3",
+        "web-streams-polyfill": "^3.2.1"
+      }
     },
     "pend": {
       "version": "1.2.0",
@@ -13725,6 +13739,11 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,10 @@
   },
   "dependencies": {
     "@types/lodash.debounce": "^4.0.6",
-    "@types/pdfjs-dist": "^2.7.4",
     "@types/react": "^16.4.0",
     "@types/react-dom": "^16.4.0",
     "lodash.debounce": "^4.0.8",
-    "pdfjs-dist": "2.11.338",
+    "pdfjs-dist": "2.16.105",
     "react-rnd": "^10.1.10"
   },
   "repository": {

--- a/src/components/PdfHighlighter.tsx
+++ b/src/components/PdfHighlighter.tsx
@@ -6,6 +6,7 @@ import {
   EventBus,
   PDFViewer,
   PDFLinkService,
+  NullL10n,
 } from "pdfjs-dist/legacy/web/pdf_viewer";
 
 import "pdfjs-dist/web/pdf_viewer.css";
@@ -181,8 +182,7 @@ export class PdfHighlighter<T_HT extends IHighlight> extends PureComponent<
         textLayerMode: 2,
         removePageBorders: true,
         linkService: this.linkService,
-        renderer: "canvas",
-        l10n: null,
+        l10n: NullL10n,
       });
 
     this.linkService.setDocument(pdfDocument);

--- a/src/components/PdfLoader.tsx
+++ b/src/components/PdfLoader.tsx
@@ -28,7 +28,7 @@ export class PdfLoader extends Component<Props, State> {
   };
 
   static defaultProps = {
-    workerSrc: "https://unpkg.com/pdfjs-dist@2.11.338/build/pdf.worker.min.js",
+    workerSrc: "https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.worker.min.js",
   };
 
   documentRef = React.createRef<HTMLElement>();


### PR DESCRIPTION
The PDF.js is already at version 3, but the intention of this MR is to bump it to version `2.16.105` which was the latest patch for version 2.

The reason to not go ahead and update to version 3 is that it completely removes `enhanceTextSelection` and this is one of the few ways to solve the selection issues in some pdfs.

Version `2.16.105` brings enhancements compared to version `2.11.338` like loading pages faster, some fixes for signatures not showing, and a few more that you can check in their release notes for each version ahead of it.