### PR TITLE
Fix AreaHighlight positioning issue

### DIFF
--- a/src/style/AreaHighlight.css
+++ b/src/style/AreaHighlight.css
@@ -1,5 +1,4 @@
 .AreaHighlight {
-  border: 1px solid #333;
   background-color: rgba(252, 232, 151, 1.0);
   opacity: 1;
   mix-blend-mode: multiply;


### PR DESCRIPTION
The 1px border shifted each rendered AreaHighlight by an offset. The more AreaHighlights were, added the bigger the shift. The consequence was, that if many AreaHighlights were added to a document, the highlights were not rendered to the correct positions. It also resulted in a misfit between the position of a highlight that was drawn and how it was rendered after the annotation was added.
Removing the css border Attribute fixes these issues. If the border is desired, it can be added to the `AreaHighlight__part` css