### PR TITLE
Update package.json

### DIFF
--- a/create-react-app-example/package.json
+++ b/create-react-app-example/package.json
@@ -19,7 +19,7 @@
     "eject": "react-scripts eject",
     "postinstall": "npm run sync-source-files",
     "clean": "rm -rf ./src/{style,index.tsx,App.tsx,Sidebar.tsx,Spinner.tsx,test-highlights.ts}",
-    "sync-source-files": "npm run clean && rsync --recursive --ignore-existing --verbose ../example/src/* ./src"
+    "sync-source-files": "npm run clean && cp -r ../example/src/* ./src"
   },
   "eslintConfig": {
     "extends": [

--- a/create-react-app-example/package.json
+++ b/create-react-app-example/package.json
@@ -10,16 +10,17 @@
     "react-dom": "^17.0.2",
     "react-pdf-highlighter": "../",
     "react-scripts": "^5.0.1",
-    "typescript": "^4.4.2"
+    "typescript": "^4.4.2",
+    "cross-env": "^7.0.3"
   },
   "scripts": {
     "dev": "npm run start",
-    "start": "GENERATE_SOURCEMAP=false react-scripts start",
-    "build": "GENERATE_SOURCEMAP=false react-scripts build",
+    "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
+    "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
     "eject": "react-scripts eject",
     "postinstall": "npm run sync-source-files",
     "clean": "rm -rf ./src/{style,index.tsx,App.tsx,Sidebar.tsx,Spinner.tsx,test-highlights.ts}",
-    "sync-source-files": "npm run clean && cp -r ../example/src/* ./src"
+    "sync-source-files": "npm run clean && cp -r ../example/src/* ./src/"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
rsync is not available on Windows, so we use cp instead && fixes: `'GENERATE_SOURCEMAP' is not recognized as an internal or external command,` error on Windows