### PR TITLE
move types to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@types/lodash.debounce": "^4.0.6",
-        "@types/react": "^16.4.0",
-        "@types/react-dom": "^16.4.0",
         "lodash.debounce": "^4.0.8",
         "pdfjs-dist": "2.16.105",
         "react-rnd": "^10.1.10"
       },
       "devDependencies": {
+        "@types/lodash.debounce": "^4.0.6",
+        "@types/react": "^16.4.0",
+        "@types/react-dom": "^16.4.0",
         "@vitejs/plugin-react-refresh": "^1.3.1",
         "jest": "^27.1.0",
         "jest-puppeteer": "^6.1.0",
@@ -1468,12 +1468,14 @@
     "node_modules/@types/lodash": {
       "version": "4.14.172",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
-      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+      "dev": true
     },
     "node_modules/@types/lodash.debounce": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
       "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -1493,12 +1495,14 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "16.14.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.14.tgz",
       "integrity": "sha512-uwIWDYW8LznHzEMJl7ag9St1RsK0gw/xaFZ5+uI1ZM1HndwUgmPH3/wQkSb87GkOVg7shUxnpNW8DcN0AzvG5Q==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1509,6 +1513,7 @@
       "version": "16.9.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
       "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+      "dev": true,
       "dependencies": {
         "@types/react": "^16"
       }
@@ -1516,7 +1521,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2453,7 +2459,8 @@
     "node_modules/csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "dev": true
     },
     "node_modules/cwd": {
       "version": "0.10.0",
@@ -9230,12 +9237,14 @@
     "@types/lodash": {
       "version": "4.14.172",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
-      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+      "dev": true
     },
     "@types/lodash.debounce": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
       "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
       "requires": {
         "@types/lodash": "*"
       }
@@ -9255,12 +9264,14 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
     },
     "@types/react": {
       "version": "16.14.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.14.tgz",
       "integrity": "sha512-uwIWDYW8LznHzEMJl7ag9St1RsK0gw/xaFZ5+uI1ZM1HndwUgmPH3/wQkSb87GkOVg7shUxnpNW8DcN0AzvG5Q==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -9271,6 +9282,7 @@
       "version": "16.9.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
       "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+      "dev": true,
       "requires": {
         "@types/react": "^16"
       }
@@ -9278,7 +9290,8 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -10047,7 +10060,8 @@
     "csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "dev": true
     },
     "cwd": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "react-dom": ">=16.4.0"
   },
   "dependencies": {
-    "@types/lodash.debounce": "^4.0.6",
-    "@types/react": "^16.4.0",
-    "@types/react-dom": "^16.4.0",
     "lodash.debounce": "^4.0.8",
     "pdfjs-dist": "2.16.105",
     "react-rnd": "^10.1.10"
@@ -49,6 +46,9 @@
     "url": "https://github.com/agentcooper/react-pdf-highlighter/issues"
   },
   "devDependencies": {
+    "@types/lodash.debounce": "^4.0.6",
+    "@types/react": "^16.4.0",
+    "@types/react-dom": "^16.4.0",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "jest": "^27.1.0",
     "jest-puppeteer": "^6.1.0",


### PR DESCRIPTION
Resolves issues like the one below:
```
error TS2786: 'Tip' cannot be used as a JSX component.
  Its type 'typeof Tip' is not a valid JSX element type.
    Type 'typeof Tip' is not assignable to type 'new (props: any) => Component<any, any, any>'.
      Construct signature return types 'Tip' and 'Component<any, any, any>' are incompatible.
        The types of 'refs' are incompatible between these types.
          Type '*** [key: string]: import("/~/node_modules/react-pdf-highlighter/node_modules/@types/react/index").ReactInstance; ***' is not assignable to type '*** [key: string]: React.ReactInstance; ***'.
            'string' index signatures are incompatible.
              Type 'import("~/node_modules/react-pdf-highlighter/node_modules/@types/react/index").ReactInstance' is not assignable to type 'React.ReactInstance'.
```