### PR TITLE
fix bug in pdfCoordinates.

### DIFF
--- a/src/lib/coordinates.ts
+++ b/src/lib/coordinates.ts
@@ -13,7 +13,7 @@ interface WIDTH_HEIGHT {
 
 export const viewportToScaled = (
   rect: LTWHP,
-  { width, height }: WIDTH_HEIGHT
+  { width, height }: WIDTH_HEIGHT,
 ): Scaled => {
   return {
     x1: rect.left,
@@ -38,8 +38,8 @@ const pdfToViewport = (pdf: Scaled, viewport: Viewport): LTWHP => {
   ]);
 
   return {
-    left: Math.min(x1,x2),
-    top: Math.min(y1,y2),
+    left: Math.min(x1, x2),
+    top: Math.min(y1, y2),
 
     width: Math.abs(x2 - x1),
     height: Math.abs(y1 - y2),
@@ -51,7 +51,7 @@ const pdfToViewport = (pdf: Scaled, viewport: Viewport): LTWHP => {
 export const scaledToViewport = (
   scaled: Scaled,
   viewport: Viewport,
-  usePdfCoordinates: boolean = false
+  usePdfCoordinates: boolean = false,
 ): LTWHP => {
   const { width, height } = viewport;
 

--- a/src/lib/coordinates.ts
+++ b/src/lib/coordinates.ts
@@ -38,11 +38,11 @@ const pdfToViewport = (pdf: Scaled, viewport: Viewport): LTWHP => {
   ]);
 
   return {
-    left: x1,
-    top: y1,
+    left: Math.min(x1,x2),
+    top: Math.min(y1,y2),
 
-    width: x2 - x1,
-    height: y1 - y2,
+    width: Math.abs(x2 - x1),
+    height: Math.abs(y1 - y2),
 
     pageNumber: pdf.pageNumber,
   };


### PR DESCRIPTION
The existing code has a bug since it sets the top of the rectangle to y1. This implies y1 < y2. However, the height is calculated as y1 - y2 (which would be negative). 

There is a one character fix (i.e., set height = y2 - y1), but, the provided patch is more robust to misunderstandings by the user about what order the coordinates are provided in.