### PR TITLE
Fix mouse selection on resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:copy-styles && npm run build:example",
     "build:esm": "tsc",
     "build:cjs": "tsc --module commonjs --outDir ./dist/cjs",
-    "build:copy-styles": "cp -r ./src/style ./dist/esm; cp -r ./src/style ./dist/cjs",
+    "build:copy-styles": "cp -r ./src/style ./dist/esm && cp -r ./src/style ./dist/cjs",
     "build:example": "(cd ./example && tsc && vite build)",
     "test": "tsc && npm run format:check && npm run test:integration",
     "test:integration": "BROWSER=none jest --maxWorkers=1 -c jest.config.js",

--- a/src/components/MouseSelection.tsx
+++ b/src/components/MouseSelection.tsx
@@ -81,9 +81,7 @@ class MouseSelection extends Component<Props, State> {
     let containerBoundingRect: DOMRect | null = null;
 
     const containerCoords = (pageX: number, pageY: number) => {
-      if (!containerBoundingRect) {
-        containerBoundingRect = container.getBoundingClientRect();
-      }
+      containerBoundingRect ||= container.getBoundingClientRect();
 
       return {
         x: pageX - containerBoundingRect.left + container.scrollLeft,
@@ -120,6 +118,7 @@ class MouseSelection extends Component<Props, State> {
       }
 
       onDragStart();
+      containerBoundingRect = container.getBoundingClientRect();
 
       this.setState({
         start: containerCoords(event.pageX, event.pageY),


### PR DESCRIPTION
This is just a simple fix for issue #259 . Before, the `containerBounderRect` in `MouseSelection` was only being set whenever `containerCoords` was first called. Since MouseSelection doesn't re-mount on a resize, `containerBoundingRect` doesn't get reset to null and then re-initialised, breaking the calculated coords.

All this fix does is set `containerBoundingRect` to the latest clientRect whenever mouseDown is called. This adds some extra unnecessary overhead, but the alternative is resetting the variable on resize from the PdfHighlighter or remounting the MouseSelection entirely. I may have forgotten another way, though 😂.

I also just made a very small change to `build:copy-styles` to make it safer.