### PR TITLE
Fix CORS errors

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -44,8 +44,8 @@ const HighlightPopup = ({
     </div>
   ) : null;
 
-const PRIMARY_PDF_URL = "https://arxiv.org/pdf/1708.08021.pdf";
-const SECONDARY_PDF_URL = "https://arxiv.org/pdf/1604.02480.pdf";
+const PRIMARY_PDF_URL = "https://arxiv.org/pdf/1708.08021";
+const SECONDARY_PDF_URL = "https://arxiv.org/pdf/1604.02480";
 
 const searchParams = new URLSearchParams(document.location.search);
 

--- a/example/src/test-highlights.ts
+++ b/example/src/test-highlights.ts
@@ -1,5 +1,5 @@
 export const testHighlights = {
-  "https://arxiv.org/pdf/1708.08021.pdf": [
+  "https://arxiv.org/pdf/1708.08021": [
     {
       content: {
         text: " Type Checking for JavaScript",
@@ -279,7 +279,7 @@ export const testHighlights = {
       },
     },
   ],
-  "https://arxiv.org/pdf/1604.02480.pdf": [
+  "https://arxiv.org/pdf/1604.02480": [
     {
       content: {
         text: "SSA",


### PR DESCRIPTION
Fix for #272 .

Switching from file links like `https://arxiv.org/pdf/1604.02480.pdf` to `https://arxiv.org/pdf/1604.02480` seems to add back CORS.