### PR TITLE
fix: add dependency highlights in function callback scrollToHighlight…

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -74,7 +74,7 @@ export function App() {
     if (highlight) {
       scrollViewerTo.current(highlight);
     }
-  }, []);
+  }, [highlights]);
 
   useEffect(() => {
     window.addEventListener("hashchange", scrollToHighlightFromHash, false);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -69,12 +69,13 @@ export function App() {
 
   const scrollViewerTo = useRef((highlight: IHighlight) => {});
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies(a): <inside getHighlightById is using array highlights>
   const scrollToHighlightFromHash = useCallback(() => {
     const highlight = getHighlightById(parseIdFromHash());
     if (highlight) {
       scrollViewerTo.current(highlight);
     }
-  }, []);
+  }, [highlights]);
 
   useEffect(() => {
     window.addEventListener("hashchange", scrollToHighlightFromHash, false);


### PR DESCRIPTION
Need add dependency  to get latest array highlights

Test case:
Add a new 1 highlight

Click to newest highlight=> not working if not use dependency highlights in function callback scrollToHighlightFromHash